### PR TITLE
Video record started stopped listeners

### DIFF
--- a/cameraViewEx/src/main/api21/com/priyankvasa/android/cameraviewex/Camera2.kt
+++ b/cameraViewEx/src/main/api21/com/priyankvasa/android/cameraviewex/Camera2.kt
@@ -184,9 +184,12 @@ internal open class Camera2(
 
             GlobalScope.launch(Dispatchers.Main) { mediaRecorder?.start() }
                     .invokeOnCompletion { t ->
-                        if (t != null) {
-                            listener.onCameraError(CameraViewException("Camera device is already in use", t))
-                            isVideoRecording = false
+                        when (t) {
+                            null -> listener.onVideoRecordStarted()
+                            else -> {
+                                listener.onCameraError(CameraViewException("Camera device is already in use", t))
+                                isVideoRecording = false
+                            }
                         }
                     }
         }
@@ -1250,6 +1253,7 @@ internal open class Camera2(
     }
 
     override fun stopVideoRecording(): Boolean = runCatching {
+        listener.onVideoRecordStopped()
         mediaRecorder?.stop()
         mediaRecorder?.reset()
         captureSession?.close()

--- a/cameraViewEx/src/main/api21/com/priyankvasa/android/cameraviewex/Camera2.kt
+++ b/cameraViewEx/src/main/api21/com/priyankvasa/android/cameraviewex/Camera2.kt
@@ -1253,8 +1253,8 @@ internal open class Camera2(
     }
 
     override fun stopVideoRecording(): Boolean = runCatching {
-        listener.onVideoRecordStopped()
         mediaRecorder?.stop()
+        listener.onVideoRecordStopped()
         mediaRecorder?.reset()
         captureSession?.close()
         startPreviewCaptureSession()

--- a/cameraViewEx/src/main/base/com/priyankvasa/android/cameraviewex/CameraInterface.kt
+++ b/cameraViewEx/src/main/base/com/priyankvasa/android/cameraviewex/CameraInterface.kt
@@ -73,6 +73,8 @@ internal interface CameraInterface : LifecycleOwner {
         suspend fun onCameraOpened()
         suspend fun onCameraClosed()
         fun onPictureTaken(imageData: ByteArray)
+        fun onVideoRecordStarted()
+        fun onVideoRecordStopped()
         fun onCameraError(
                 e: Exception,
                 errorLevel: ErrorLevel = ErrorLevel.Error,

--- a/cameraViewEx/src/main/java/com/priyankvasa/android/cameraviewex/CameraView.kt
+++ b/cameraViewEx/src/main/java/com/priyankvasa/android/cameraviewex/CameraView.kt
@@ -58,6 +58,8 @@ class CameraView @JvmOverloads constructor(
     private var previewFrameListener: ((image: Image) -> Unit)? = null
     private val cameraErrorListeners = HashSet<(t: Throwable, errorLevel: ErrorLevel) -> Unit>()
     private val cameraClosedListeners = HashSet<() -> Unit>()
+    private val videoRecordStartedListeners = HashSet<() -> Unit>()
+    private val videoRecordStoppedListeners = HashSet<() -> Unit>()
 
     private val listener = object : CameraInterface.Listener {
 
@@ -81,6 +83,8 @@ class CameraView @JvmOverloads constructor(
             pictureTakenListeners.clear()
             cameraErrorListeners.clear()
             cameraClosedListeners.clear()
+            videoRecordStartedListeners.clear()
+            videoRecordStoppedListeners.clear()
         }
 
         override suspend fun onCameraOpened() {
@@ -108,6 +112,14 @@ class CameraView @JvmOverloads constructor(
 
         override suspend fun onCameraClosed() {
             cameraClosedListeners.forEach { it.invoke() }
+        }
+
+        override fun onVideoRecordStarted() {
+            videoRecordStartedListeners.forEach { it.invoke() }
+        }
+
+        override fun onVideoRecordStopped() {
+            videoRecordStoppedListeners.forEach { it.invoke() }
         }
     }
 
@@ -546,6 +558,46 @@ class CameraView @JvmOverloads constructor(
      */
     fun removeCameraClosedListener(listener: () -> Unit): CameraView {
         cameraClosedListeners.remove(listener)
+        return this
+    }
+
+    /**
+     * Add a new video record started [listener].
+     * @param listener lambda
+     * @return instance of [CameraView] it was called on
+     */
+    fun addVideoRecordStartedListener(listener: () -> Unit): CameraView {
+        videoRecordStartedListeners.add(listener)
+        return this
+    }
+
+    /**
+     * Remove video record started [listener].
+     * @param listener that was previously added.
+     * @return instance of [CameraView] it is called on
+     */
+    fun removeVideoRecordStartedListener(listener: () -> Unit): CameraView {
+        videoRecordStartedListeners.remove(listener)
+        return this
+    }
+
+    /**
+     * Add a new video record stopped [listener].
+     * @param listener lambda
+     * @return instance of [CameraView] it was called on
+     */
+    fun addVideoRecordStoppedListener(listener: () -> Unit): CameraView {
+        videoRecordStoppedListeners.add(listener)
+        return this
+    }
+
+    /**
+     * Remove video record stopped [listener].
+     * @param listener that was previously added.
+     * @return instance of [CameraView] it is called on
+     */
+    fun removeVideoRecordStoppedListener(listener: () -> Unit): CameraView {
+        videoRecordStoppedListeners.remove(listener)
         return this
     }
 


### PR DESCRIPTION
Currently the only way to know when a video is started or stopped is by tracking it in the activity. For example when making the library call to start or stop the video capture. 

Problems:
- When using maxDuration there is no way to know that the recording stopped
- When using any kind of a display timer or countdown there is too much "slop" time between the library call and when things actually start

Added listeners for when the video is started and stopped. Did some timed tests for the total time between the library call to start until the stop listener was triggered and also the time between the start and stop triggers.

Max video duration set to 3000:
Total time: 4070, Listener time: 3358
Total time: 3951, Listener time: 3350
Total time: 4030, Listener time: 3392

This is going to vary per device but with the listener we can get much closer to the actual recording time.